### PR TITLE
Remove deprecated RPC endpoints from DAO configurations

### DIFF
--- a/daos/aquari-dao.yml
+++ b/daos/aquari-dao.yml
@@ -50,7 +50,6 @@ chain:
 indexer:
   endpoint: https://indexer.degov.ai/aquari-dao/graphql
   startBlock: 32888284
-  rpc: https://erpc.ringdao.com/main/evm/8453
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
 aiAgent:

--- a/daos/awe-dao.yml
+++ b/daos/awe-dao.yml
@@ -32,7 +32,6 @@ chain:
 indexer:
   endpoint: https://indexer.degov.ai/awe-dao/graphql
   startBlock: 26359902
-  rpc: https://erpc.ringdao.com/main/evm/8453
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
 aiAgent:

--- a/daos/carv-dao.yml
+++ b/daos/carv-dao.yml
@@ -32,7 +32,6 @@ chain:
 indexer:
   endpoint: https://indexer.degov.ai/carv-dao/graphql
   startBlock: 28738113
-  rpc: https://erpc.ringdao.com/main/evm/8453
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
 aiAgent:

--- a/daos/ens-dao.yml
+++ b/daos/ens-dao.yml
@@ -36,7 +36,6 @@ chain:
 indexer:
   endpoint: https://indexer.degov.ai/ens-dao/graphql
   startBlock: 13533418
-  rpc: https://erpc.ringdao.com/main/evm/1
   gateway: https://v2.archive.subsquid.io/network/ethereum-mainnet
 
 aiAgent:

--- a/daos/gmx-dao.yml
+++ b/daos/gmx-dao.yml
@@ -33,7 +33,6 @@ chain:
 indexer:
   endpoint: https://indexer.degov.ai/gmx-dao/graphql
   startBlock: 168596066
-  rpc: https://erpc.ringdao.com/main/evm/42161
   gateway: https://v2.archive.subsquid.io/network/arbitrum-one
 
 aiAgent:

--- a/daos/hai-dao.yml
+++ b/daos/hai-dao.yml
@@ -35,7 +35,6 @@ chain:
 indexer:
   endpoint: https://indexer.degov.ai/hai-dao/graphql
   startBlock: 116055145
-  rpc: https://erpc.ringdao.com/main/evm/10
   gateway: https://v2.archive.subsquid.io/network/optimism-mainnet
 
 aiAgent:

--- a/daos/internet-token-dao.yml
+++ b/daos/internet-token-dao.yml
@@ -31,7 +31,6 @@ chain:
 indexer:
   endpoint: https://indexer.degov.ai/internet-token-dao/graphql
   startBlock: 12149008
-  rpc: https://erpc.ringdao.com/main/evm/8453
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
 aiAgent:

--- a/daos/lazy-summer.yml
+++ b/daos/lazy-summer.yml
@@ -35,7 +35,6 @@ chain:
 indexer:
   endpoint: https://indexer.degov.ai/lazy-summer-dao/graphql
   startBlock: 25642493
-  rpc: https://erpc.ringdao.com/main/evm/8453
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
 aiAgent:

--- a/daos/lisk-dao.yml
+++ b/daos/lisk-dao.yml
@@ -46,7 +46,6 @@ chain:
 indexer:
   endpoint: https://indexer.degov.ai/lisk-dao/graphql
   startBlock: 568752
-  rpc: https://rpc.api.lisk.com
 
 aiAgent:
   endpoint: https://agent.degov.ai

--- a/daos/rn-dao.yml
+++ b/daos/rn-dao.yml
@@ -30,7 +30,6 @@ chain:
 indexer:
   endpoint: https://indexer.degov.ai/rn-dao/graphql
   startBlock: 191754212
-  rpc: https://erpc.ringdao.com/main/evm/42161
   gateway: https://v2.archive.subsquid.io/network/arbitrum-one
 
 aiAgent:

--- a/daos/seamless-dao.yml
+++ b/daos/seamless-dao.yml
@@ -33,7 +33,6 @@ chain:
 indexer:
   endpoint: https://indexer.degov.ai/seamless-dao/graphql
   startBlock: 3238235
-  rpc: https://erpc.ringdao.com/main/evm/8453
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
 aiAgent:

--- a/daos/truefi-dao.yml
+++ b/daos/truefi-dao.yml
@@ -36,7 +36,6 @@ chain:
 indexer:
   endpoint: https://indexer.degov.ai/truefi-dao/graphql
   startBlock: 11884565
-  rpc: https://erpc.ringdao.com/main/evm/1
   gateway: https://v2.archive.subsquid.io/network/ethereum-mainnet
 
 aiAgent:

--- a/daos/unlock-dao.yml
+++ b/daos/unlock-dao.yml
@@ -36,7 +36,6 @@ chain:
 indexer:
   endpoint: https://indexer.degov.ai/unlock-dao/graphql
   startBlock: 18035311
-  rpc: https://erpc.ringdao.com/main/evm/8453
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
 aiAgent:

--- a/daos/virtuals-dao.yml
+++ b/daos/virtuals-dao.yml
@@ -36,7 +36,6 @@ chain:
 indexer:
   endpoint: https://indexer.degov.ai/virtuals-dao/graphql
   startBlock: 11841008
-  rpc: https://erpc.ringdao.com/main/evm/8453
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
 aiAgent:


### PR DESCRIPTION

The indexing program has been upgraded, this field is no longer required, it is just a supplement
