### PR TITLE
Remove aiAgent field from schema and all DAO entries

### DIFF
--- a/daos/aixbt-dao.yml
+++ b/daos/aixbt-dao.yml
@@ -38,8 +38,6 @@ indexer:
   startBlock: 21867924
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0x48880738f4Ccafd105a8d75Cf8c64052F33b543f"

--- a/daos/aquari-dao.yml
+++ b/daos/aquari-dao.yml
@@ -57,8 +57,6 @@ indexer:
   startBlock: 32888284
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0x062f87ae9eCAd31398C0cF5Ef269feb9050b9DF6"

--- a/daos/awe-dao.yml
+++ b/daos/awe-dao.yml
@@ -39,8 +39,6 @@ indexer:
   startBlock: 26359902
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0xAe18Aed3Dd3c9cd1d0A180315B6b5FCd61eF20f1"

--- a/daos/carv-dao.yml
+++ b/daos/carv-dao.yml
@@ -39,8 +39,6 @@ indexer:
   startBlock: 28738113
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0xe5C7Fc2B5562704902FbCF8Dfb1D36016a480612"

--- a/daos/degov-blocknumber.yml
+++ b/daos/degov-blocknumber.yml
@@ -42,8 +42,6 @@ indexer:
   endpoint: https://indexer.degov.ai/demo-blocknumber-dao/graphql
   startBlock: 7754389
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0x398d514611291aB0C1c7c8447589A15b4bD08E3D"

--- a/daos/degov-no-timelock.yml
+++ b/daos/degov-no-timelock.yml
@@ -38,8 +38,6 @@ indexer:
   endpoint: https://indexer.degov.ai/demo-no-timelock-dao/graphql
   startBlock: 5873342
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0x36BeEC8463D4601606958Fa58DB458B4f3C399fe"

--- a/daos/ens-dao.yml
+++ b/daos/ens-dao.yml
@@ -43,8 +43,6 @@ indexer:
   startBlock: 13533418
   gateway: https://v2.archive.subsquid.io/network/ethereum-mainnet
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0x323A76393544d5ecca80cd6ef2A560C6a395b7E3"

--- a/daos/fluence-dao.yml
+++ b/daos/fluence-dao.yml
@@ -53,8 +53,6 @@ indexer:
   startBlock: 19235767
   gateway: https://v2.archive.subsquid.io/network/ethereum-mainnet
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0x674299Cc65CEFAac9057f7EB307f5f6bB861f8E0"

--- a/daos/gmx-dao.yml
+++ b/daos/gmx-dao.yml
@@ -40,8 +40,6 @@ indexer:
   startBlock: 168596066
   gateway: https://v2.archive.subsquid.io/network/arbitrum-one
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0x03e8f708e9C85EDCEaa6AD7Cd06824CeB82A7E68"

--- a/daos/hai-dao.yml
+++ b/daos/hai-dao.yml
@@ -42,8 +42,6 @@ indexer:
   startBlock: 116055145
   gateway: https://v2.archive.subsquid.io/network/optimism-mainnet
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0xe807f3282f3391d237BA8B9bECb0d8Ea3ba23777"

--- a/daos/internet-token-dao.yml
+++ b/daos/internet-token-dao.yml
@@ -38,8 +38,6 @@ indexer:
   startBlock: 12149008
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0xc5C3a1882Eff9539527D88E2453cAB10d9bc1581"

--- a/daos/kton-dao.yml
+++ b/daos/kton-dao.yml
@@ -35,8 +35,6 @@ indexer:
   endpoint: https://indexer.degov.ai/kton-dao/graphql
   startBlock: 3320858
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0xaAC63c40930cCAF99603229F6381D82966b145ef"

--- a/daos/lazy-summer.yml
+++ b/daos/lazy-summer.yml
@@ -42,8 +42,6 @@ indexer:
   startBlock: 25642493
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0xBE5A4DD68c3526F32B454fE28C9909cA0601e9Fa"

--- a/daos/lisk-dao.yml
+++ b/daos/lisk-dao.yml
@@ -52,8 +52,6 @@ indexer:
   endpoint: https://indexer.degov.ai/lisk-dao/graphql
   startBlock: 568752
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0x58a61b1807a7bDA541855DaAEAEe89b1DDA48568"

--- a/daos/ring-dao-guild.yml
+++ b/daos/ring-dao-guild.yml
@@ -37,8 +37,6 @@ indexer:
   endpoint: https://indexer.degov.ai/ring-dao-guild/graphql
   startBlock: 2639678
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0x234179ae929D886fceA83a6D04af69A86134AA3B"

--- a/daos/ring-dao.yml
+++ b/daos/ring-dao.yml
@@ -46,8 +46,6 @@ indexer:
   endpoint: https://indexer.degov.ai/ring-dao/graphql
   startBlock: 4455584
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0x52cDD25f7C83c335236Ce209fA1ec8e197E96533"

--- a/daos/rn-dao.yml
+++ b/daos/rn-dao.yml
@@ -37,8 +37,6 @@ indexer:
   startBlock: 191754212
   gateway: https://v2.archive.subsquid.io/network/arbitrum-one
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0xf73EE8B7AE7ddA64CF88CD4f722241BF88237157"

--- a/daos/seamless-dao.yml
+++ b/daos/seamless-dao.yml
@@ -40,8 +40,6 @@ indexer:
   startBlock: 3238235
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0x8768c789C6df8AF1a92d96dE823b4F80010Db294"

--- a/daos/truefi-dao.yml
+++ b/daos/truefi-dao.yml
@@ -43,8 +43,6 @@ indexer:
   startBlock: 11884565
   gateway: https://v2.archive.subsquid.io/network/ethereum-mainnet
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0x585CcA060422ef1779Fb0Dd710A49e7C49A823C9"

--- a/daos/unlock-dao.yml
+++ b/daos/unlock-dao.yml
@@ -54,8 +54,6 @@ indexer:
   startBlock: 18035311
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0x65bA0624403Fc5Ca2b20479e9F626eD4D78E0aD9"

--- a/daos/virtuals-dao.yml
+++ b/daos/virtuals-dao.yml
@@ -43,8 +43,6 @@ indexer:
   startBlock: 11841008
   gateway: https://v2.archive.subsquid.io/network/base-mainnet
 
-aiAgent:
-  endpoint: https://agent.degov.ai
 
 contracts:
   governor: "0xA1a98f9Aa6C56652e4f306D38A78FfF554776665"

--- a/docs/spec/20260403__registry-contribution-guide.md
+++ b/docs/spec/20260403__registry-contribution-guide.md
@@ -104,9 +104,6 @@ indexer:
   endpoint: https://indexer.example.org/graphql
   startBlock: 123456
 
-aiAgent:
-  endpoint: https://agent.degov.ai
-
 contracts:
   governor: "0x0000000000000000000000000000000000000001"
   governorToken:
@@ -132,7 +129,6 @@ contracts:
 | `wallet` | Yes | Wallet connection settings. |
 | `chain` | Yes | Network metadata and chain access details. |
 | `indexer` | Yes | GraphQL indexer settings. |
-| `aiAgent` | Yes | AI agent endpoint used by the app. |
 | `contracts` | Yes | Governor and governance token contracts. |
 | `treasuryAssets` | No | Treasury token/NFT assets tracked for the DAO, or `null`. |
 | `safes` | No | Safe multisig wallets associated with the DAO. |
@@ -195,12 +191,6 @@ contracts:
 | `indexer.startBlock` | Yes | First block that should be indexed. |
 | `indexer.rpc` | No | Optional RPC endpoint used by the indexer. |
 | `indexer.gateway` | No | Optional archive gateway URL. |
-
-### `aiAgent`
-
-| Field | Required | Meaning |
-| --- | --- | --- |
-| `aiAgent.endpoint` | Yes | AI agent API endpoint. |
 
 ### `contracts`
 

--- a/schemas/dao.schema.json
+++ b/schemas/dao.schema.json
@@ -253,19 +253,6 @@
       "required": ["endpoint", "startBlock"],
       "additionalProperties": false
     },
-    "aiAgent": {
-      "type": "object",
-      "description": "AI agent configuration",
-      "properties": {
-        "endpoint": {
-          "type": "string",
-          "format": "uri",
-          "description": "AI agent API endpoint"
-        }
-      },
-      "required": ["endpoint"],
-      "additionalProperties": false
-    },
     "contracts": {
       "type": "object",
       "description": "Smart contract addresses",
@@ -433,7 +420,6 @@
     "wallet",
     "chain",
     "indexer",
-    "aiAgent",
     "contracts"
   ],
   "additionalProperties": false


### PR DESCRIPTION
Deprecated by degov issue #661. The aiAgent field is no longer needed in the registry schema or any DAO configuration files.