### PR TITLE
fix(registry): mark NFT governor tokens as ERC721

### DIFF
--- a/daos/content-guild-dao.yml
+++ b/daos/content-guild-dao.yml
@@ -42,5 +42,5 @@ contracts:
   governor: "0xd6387c4bD0D8DDed2f447054486fB8d7aBb98E08"
   governorToken:
     address: "0xf4A24C6371F7a4A2F679eBb0bbf27F6e12892C1b"
-    standard: ERC20
+    standard: ERC721
   timeLock: "0x34352B4021877FBa2a9F6cf768871bE4c5a0EA4F"

--- a/daos/dope-dao.yml
+++ b/daos/dope-dao.yml
@@ -44,5 +44,5 @@ contracts:
   governor: "0xDBd38F7e739709fe5bFaE6cc8eF67C3820830E0C"
   governorToken:
     address: "0x8707276DF042E89669d69A177d3DA7dC78bd8723"
-    standard: ERC20
+    standard: ERC721
   timeLock: "0xB57Ab8767CAe33bE61fF15167134861865F7D22C"

--- a/daos/fame-dao.yml
+++ b/daos/fame-dao.yml
@@ -43,5 +43,5 @@ contracts:
   governor: "0xbB2BD06084aB8AB66f14CE33fc713093E0f1d8D8"
   governorToken:
     address: "0x12cf4e3B1a07DDAC4046B18714D6bAb9063De852"
-    standard: ERC20
+    standard: ERC721
   timeLock: "0x08f0194e4ca54ebDF4C28cD06273053e0eDc2Da0"

--- a/daos/kroma-security-council-dao.yml
+++ b/daos/kroma-security-council-dao.yml
@@ -42,5 +42,5 @@ contracts:
   governor: "0xb3c415c2Aad428D5570208e1772cb68e7D06a537"
   governorToken:
     address: "0xe4D08346609055c091D3DEECdAAd3Bf83119B08c"
-    standard: ERC20
+    standard: ERC721
   timeLock: "0x22605A12cB77Fe420B0cC1263cEb58a77352FDc1"


### PR DESCRIPTION
## Summary

- Mark four NFT governor tokens as `ERC721` instead of `ERC20`.
- Fixes staging indexer decode failures where ERC721 `Transfer` logs have 4 topics and no data payload.

## Root Cause

The registry configured these governor tokens as ERC20, but chain receipts show ERC721-style `Transfer(address,address,uint256)` events with the token id indexed. The indexer selected the ERC20 ABI and failed with `Topic count mismatch. Expected 3 topics, but received 4.`

Affected DAOs:
- `content-guild-dao`
- `dope-dao`
- `fame-dao`
- `kroma-security-council-dao`

## Validation

- `ruby -ryaml -rjson ...` verified the four DAO configs now use `ERC721` and the schema enum allows it.
- `npx --yes ajv-cli validate -s schemas/dao.schema.json -d 'daos/*.yml' --spec=draft7 --validate-formats=false`
- `npx --yes ajv-cli validate -s schemas/config.schema.json -d config.yml --spec=draft7 --validate-formats=false`
