### PR TITLE
fix(public-nouns): mark governor token as ERC721

### DIFF
--- a/daos/public-nouns-dao.yml
+++ b/daos/public-nouns-dao.yml
@@ -42,5 +42,5 @@ contracts:
   governor: "0x2BbEbFECA0fEbde8C70EF8501C991f3AB2095862"
   governorToken:
     address: "0x93ecac71499147627DFEc6d0E494d50fCFFf10EE"
-    standard: ERC20
+    standard: ERC721
   timeLock: "0x553826Cb0D0Ee63155920F42b4E60aaE6607DFCB"


### PR DESCRIPTION
## Summary

This PR fixes the Public Nouns DAO governor token standard in the registry from `ERC20` to `ERC721`.

The staging v4 indexer is currently stuck while processing `public-nouns-dao` because the registry says the governor token is ERC20, but the onchain `Transfer` events emitted by the token are ERC721-shaped.

## Runtime failure observed in staging

After deploying the latest DeGov indexer image to staging, `public-nouns-dao` repeatedly exits at the same block:

- DAO: `public-nouns-dao`
- Token: `0x93ecac71499147627DFEc6d0E494d50fCFFf10EE`
- Failing block: `15637627`
- Failing transaction: `0x482abbabfc0042b57febae1b3786fbab15b8e7cad7656951555926cfe70ecc1e`
- Error:

```text
processor.event failed | contract=governorToken block=15637627 tx=0x482abbabfc0042b57febae1b3786fbab15b8e7cad7656951555926cfe70ecc1e startBlock=15637619 error="Topic count mismatch. Expected 3 topics, but received 4."
DecodingError: Topic count mismatch. Expected 3 topics, but received 4.
```

The indexer uses `contracts.governorToken.standard` to choose the `Transfer` ABI. With `ERC20`, it expects the ERC20 event shape:

```solidity
Transfer(address indexed from, address indexed to, uint256 value)
```

That event has 3 topics and the value in `data`.

## Onchain evidence

The receipt for the failing transaction contains `Transfer` logs from `0x93ecac71499147627DFEc6d0E494d50fCFFf10EE` with 4 topics and empty `data`, which is the ERC721 event shape:

```text
topic0 = 0xddf252ad...b3ef  // Transfer(address,address,uint256)
topic1 = from
topic2 = to
topic3 = tokenId
data   = 0x
```

Example logs in the failing tx:

```text
address: 0x93ecac71499147627dfec6d0e494d50fcfff10ee
topics:
  0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
  0x0000000000000000000000000000000000000000000000000000000000000000
  0x00000000000000000000000068136bf5db4407dd599960585da9b7746ecf567f
  0x0000000000000000000000000000000000000000000000000000000000000000
data: 0x
```

The same transaction also has another ERC721-shaped transfer for token id `1`.

ERC165 checks against the token contract also confirm ERC721 support:

```text
supportsInterface(0x80ac58cd) ERC721           => true
supportsInterface(0x5b5e139f) ERC721Metadata   => true
supportsInterface(0x780e9d63) ERC721Enumerable => true
```

## Why this is a registry fix

This is the same class of issue as the previous DAO token standard fixes: the processor is correctly failing fast when the configured token standard does not match the onchain event shape. Changing indexer code to ignore the decode error would hide bad registry data and risk incorrect token/delegation state.

The failed transaction was not committed by the processor, and staging is stuck at the prior processed height. Once the registry config is refreshed, the indexer can continue from the same height using the ERC721 transfer decoder.

## Validation

Local validation performed:

```text
yq -o=json '.' daos/public-nouns-dao.yml >/tmp/public-nouns-dao.json
yq -o=json '.' config.yml >/tmp/config.json
npx --yes ajv-cli validate --strict=false -s schemas/dao.schema.json -d /tmp/public-nouns-dao.json
npx --yes ajv-cli validate --strict=false -s schemas/config.schema.json -d /tmp/config.json
```

Both files validated successfully.

## Expected rollout verification

After this registry update is merged and staging config refreshes:

- `api.next.degov.ai/dao/config/public-nouns-dao` should return `contracts.governorToken.standard: ERC721`.
- `degov-staging-indexer-public-nouns-dao` should pass block `15637627`.
- Recent indexer logs should no longer show `Topic count mismatch. Expected 3 topics, but received 4.` for Public Nouns.
