### PR TITLE
feat(registry): add Base playground DAO draft

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -79,6 +79,14 @@ base:
     state: active
   - config: daos/fame-dao.yml
     state: draft
+  - config: daos/playground-dao.yml
+    state: draft
+    domains:
+      - playground.degov.ai
+      - playground.next.degov.ai
+    tags:
+      - demo
+      - playground
   # - config: daos/aquari-dao.yml
   #   state: active
   #   domains:

--- a/daos/playground-dao.yml
+++ b/daos/playground-dao.yml
@@ -1,0 +1,54 @@
+name: DeGov Playground
+code: playground-dao
+logo: https://raw.githubusercontent.com/ringecosystem/degov-registry/refs/heads/main/assets/common/degov-1024.png
+siteUrl: https://playground.degov.ai
+offChainDiscussionUrl: https://github.com/ringecosystem/degov/discussions
+editLink: https://github.com/ringecosystem/degov-registry/blob/main/daos/playground-dao.yml
+description: |
+  DeGov Playground is a public test environment for trying the DeGov
+  governance lifecycle on Base, including token distribution, delegation,
+  proposal creation, voting, Timelock queueing, execution, and notifications.
+
+links:
+  website: https://degov.ai
+  twitter: https://x.com/ringecosystem
+  discord: https://discord.gg/RingDAO
+  telegram: https://t.me/RingDAO_Hub
+  github: https://github.com/ringecosystem/degov
+
+theme:
+  logoDark: https://raw.githubusercontent.com/ringecosystem/degov-registry/refs/heads/main/assets/logos/demo-dark.svg
+  logoLight: https://raw.githubusercontent.com/ringecosystem/degov-registry/refs/heads/main/assets/logos/demo-light.svg
+  banner: https://raw.githubusercontent.com/ringecosystem/degov-registry/refs/heads/main/assets/banners/demo.jpg
+  bannerMobile: https://raw.githubusercontent.com/ringecosystem/degov-registry/refs/heads/main/assets/banners/demo-mobile.jpg
+
+wallet:
+  walletConnectProjectId: faf5e91ac5ed4d0a94d2648a6fcc9daa
+
+chain:
+  id: 8453
+  name: Base Network
+  logo: https://pbs.twimg.com/profile_images/1821025913976287232/l0WGRm5B_400x400.jpg
+  rpcs:
+    - https://base-rpc.publicnode.com
+  explorers:
+    - https://basescan.org
+  nativeToken:
+    symbol: ETH
+    decimals: 18
+    priceId: ethereum
+    logo: https://assets.coingecko.com/coins/images/279/standard/ethereum.png
+
+indexer:
+  endpoint: https://indexer.degov.ai/playground-dao/graphql
+  startBlock: 49042901
+  gateway: https://v2.archive.subsquid.io/network/base-mainnet
+
+contracts:
+  governor: "0x449337BBe404CaE0bA82f3451661AF7481f37aaC"
+  governorToken:
+    address: "0xef8ef3A1705f42e7FC1e06809940ec5942F5bB98"
+    standard: ERC20
+  timeLock: "0xa7E9dC6aBe0EfcdaBB8ED0471De0c56013066c20"
+
+treasuryAssets: null


### PR DESCRIPTION
## Summary

- add the Base Mainnet configuration for `playground-dao`
- register both `playground.degov.ai` and `playground.next.degov.ai`
- keep the entry in `draft` state with `demo` and `playground` tags
- leave the Faucet app absent until that page is implemented and verified

## Deployment baseline

- Chain ID: `8453`
- Governor: `0x449337BBe404CaE0bA82f3451661AF7481f37aaC`
- Governance token: `0xef8ef3A1705f42e7FC1e06809940ec5942F5bB98`
- Timelock: `0xa7E9dC6aBe0EfcdaBB8ED0471De0c56013066c20`
- Indexer start block: `49042901`

## Validation

- `config.yml` validated against `schemas/config.schema.json`
- `daos/playground-dao.yml` validated against `schemas/dao.schema.json`
- all DAO YAML files parsed successfully
- Registry assertions confirmed draft state, both domains, tags, unique DAO code, Base chain ID, exact start block, and absence of `apps`
- `git diff --check`

Related to ringecosystem/degov#1010.