### PR TITLE
fix(registry): use shared WalletConnect project for playground

### DIFF
--- a/daos/playground-dao.yml
+++ b/daos/playground-dao.yml
@@ -23,7 +23,7 @@ theme:
   bannerMobile: https://raw.githubusercontent.com/ringecosystem/degov-registry/refs/heads/main/assets/banners/demo-mobile.jpg
 
 wallet:
-  walletConnectProjectId: faf5e91ac5ed4d0a94d2648a6fcc9daa
+  walletConnectProjectId: 4e204efdf64201e155ce7ad7123d127d
 
 chain:
   id: 8453


### PR DESCRIPTION
## What changed

- switch the Playground DAO from the demo-only WalletConnect project to the shared project used by current public DAOs

## Why

Browser validation on `playground.next.degov.ai` showed that the demo project rejected the new origin through the Reown allowlist. Reusing the existing public DAO project avoids a Playground-specific external configuration dependency.

## Validation

- YAML parse
- exact project ID assertion
- `git diff --check`