### PR TITLE
fix(registry): preserve Playground WalletConnect project

### DIFF
--- a/daos/playground-dao.yml
+++ b/daos/playground-dao.yml
@@ -23,7 +23,7 @@ theme:
   bannerMobile: https://raw.githubusercontent.com/ringecosystem/degov-registry/refs/heads/main/assets/banners/demo-mobile.jpg
 
 wallet:
-  walletConnectProjectId: 4e204efdf64201e155ce7ad7123d127d
+  walletConnectProjectId: faf5e91ac5ed4d0a94d2648a6fcc9daa
 
 chain:
   id: 8453


### PR DESCRIPTION
## Summary

- restore the existing WalletConnect project ID for the Base Playground
- keep WalletConnect project ownership and domain allowlisting unchanged

## Validation

- `git diff --check`
- registry schema validation will run in CI

Closes the incorrect project-ID change from #127; the Playground domains will be added to the existing project allowlist.