### PR TITLE
feat(registry): activate Playground DAO

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -80,7 +80,7 @@ base:
   - config: daos/fame-dao.yml
     state: draft
   - config: daos/playground-dao.yml
-    state: draft
+    state: active
     domains:
       - playground.degov.ai
       - playground.next.degov.ai


### PR DESCRIPTION
## Summary

- promote `playground-dao` from `draft` to `active`
- retain the existing Base chain, domains, contract addresses, indexer endpoint, start block, and WalletConnect project ID
- keep Faucet delivery out of scope

## Validation

- production and staging Playground sites return the correct `DeGov Playground` application
- the production scoped GraphQL endpoint returns the exact Base contract set with a completed initial checkpoint and no persisted error
- all three Base contracts have runtime bytecode
- production indexer deployment is Ready with zero container restarts
- YAML parsing and `git diff --check` pass locally

Related: ringecosystem/degov#1010
