### PR TITLE
fix(registry): list Playground DAO in Square

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -85,7 +85,6 @@ base:
       - playground.degov.ai
       - playground.next.degov.ai
     tags:
-      - demo
       - playground
   # - config: daos/aquari-dao.yml
   #   state: active


### PR DESCRIPTION
## Summary

- remove the `demo` tag from the active `playground-dao` Registry entry
- retain the `playground` tag and every deployment/runtime field unchanged

## Why

DeGov Square intentionally filters entries whose Registry tags include `demo`:

```ts
.filter((dao) => !dao.tags?.includes('demo'))
```

After activation, the Square backend correctly synced `playground-dao` as `ACTIVE`, but the frontend continued hiding it because the entry still carried the `demo` tag. Removing that tag makes the public Base Playground discoverable alongside the other active DAOs.

## Validation

- YAML parses successfully
- `git diff --check` passes
- the only diff is removal of one tag
- active state, both domains, chain, contracts, start block, indexer endpoint, and WalletConnect project ID remain unchanged

Related: ringecosystem/degov#1010
