### PR TITLE
fix(kton): map degov domain in registry

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,6 +3,8 @@ darwinia:
     state: active
   - config: daos/kton-dao.yml
     state: active
+    domains:
+      - kton.degov.ai
   - config: daos/ring-dao-guild.yml
     state: active
 


### PR DESCRIPTION
Add kton.degov.ai to the KtonDAO registry domain index so origin-based remote config resolution works for the new production domain.